### PR TITLE
Improved bedfile query behaviors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ COMBINED_LDADD = $(BOOST_LDFLAGS) -lboost_program_options -lboost_system -lboost
 
 interpolate_genetic_position_out_SOURCES = interpolate-genetic-position/main.cc $(COMBINED_SOURCES)
 interpolate_genetic_position_out_LDADD = $(COMBINED_LDADD)
-UNIT_TEST_SOURCES = unit_tests/bedfile_queries_test.cc unit_tests/bigwig_reader_test.cc unit_tests/bigwig_reader_test.h unit_tests/cargs_test.cc unit_tests/cargs_test.h unit_tests/input_genetic_map_file_test.cc unit_test/input_genetic_map_file_test.h unit_tests/input_variant_file_test.cc unit_tests/input_variant_file_test.h unit_tests/genetic_map_test.cc unit_tests/genetic_map_test.h unit_tests/output_variant_file_test.cc unit_tests/output_variant_file_test.h unit_tests/query_file_test.cc unit_tests/utilities_test.cc integration_tests/integration_test.cc integration_tests/integration_test.h
+UNIT_TEST_SOURCES = unit_tests/bedfile_queries_test.cc unit_tests/bigwig_reader_test.cc unit_tests/bigwig_reader_test.h unit_tests/cargs_test.cc unit_tests/cargs_test.h unit_tests/input_genetic_map_file_test.cc unit_test/input_genetic_map_file_test.h unit_tests/input_variant_file_test.cc unit_tests/input_variant_file_test.h unit_tests/genetic_map_test.cc unit_tests/genetic_map_test.h unit_tests/output_variant_file_test.cc unit_tests/output_variant_file_test.h unit_tests/query_file_test.cc unit_tests/utilities_test.cc unit_tests/vardata_test.cc integration_tests/integration_test.cc integration_tests/integration_test.h
 test_suite_out_SOURCES = $(COMBINED_SOURCES) $(UNIT_TEST_SOURCES)
 test_suite_out_LDADD = $(COMBINED_LDADD) -lgtest_main -lgtest -lgmock -lpthread
 

--- a/integration_tests/integration_test.cc
+++ b/integration_tests/integration_test.cc
@@ -420,10 +420,11 @@ TEST_F(integrationTest, bedfileInputBoltOutputSparseQueries) {
       "chr22\t17086809\t17087057\t7.31739e-12\t0.00353872510698944\n");
   std::string expected_output =
       "chr\tposition\tCOMBINED_rate(cM/Mb)\tGenetic_Map(cM)\n"
-      "chr22\t17083847\t4.00811\t0.000387462396\n"
-      "chr22\t17084018\t1.91398e-06\t0.001072849206\n"
-      "chr22\t17084051\t1.91398e-06\t0.001072849\n"
-      "chr22\t17084146\t0\t0.001072849\n";
+      "chr22\t17083847\t4.00811\t0.000387462\n"
+      "chr22\t17084001\t4.00811\t0.00100471\n"
+      "chr22\t17084018\t1.91398e-06\t0.00107285\n"
+      "chr22\t17084051\t1.91398e-06\t0.00107285\n"
+      "chr22\t17084146\t0\t0.00107285\n";
   igp::interpolator ip;
   ip.interpolate(_in_query_tmpfile, "bed", _in_gmap_tmpfile, "bedgraph",
                  _out_tmpfile, "bolt", false, 0.0, false);

--- a/integration_tests/integration_test.cc
+++ b/integration_tests/integration_test.cc
@@ -404,3 +404,30 @@ TEST_F(integrationTest, bigwigGeneticMap) {
   std::string observed_output = load_plaintext_file(_out_tmpfile);
   EXPECT_EQ(expected_output, observed_output);
 }
+
+TEST_F(integrationTest, bedfileInputBoltOutputSparseQueries) {
+  std::string input_query =
+      create_plaintext_file(_in_query_tmpfile,
+                            "chr22\t17083846\t17084000\tthing1\n"
+                            "chr22\t17084050\t17084145\tthing2\n");
+  std::string input_gmap = create_plaintext_file(
+      _in_gmap_tmpfile,
+      "chr22\t17076254\t17081023\t0\t0\n"
+      "chr22\t17081023\t17083846\t0.137252\t0\n"
+      "chr22\t17083846\t17084017\t4.00811\t0.000387462396\n"
+      "chr22\t17084017\t17084145\t1.91398e-06\t0.001072849206\n"
+      "chr22\t17084145\t17086809\t0.925629\t0.00107284945098944\n"
+      "chr22\t17086809\t17087057\t7.31739e-12\t0.00353872510698944\n");
+  std::string expected_output =
+      "chr\tposition\tCOMBINED_rate(cM/Mb)\tGenetic_Map(cM)\n"
+      "chr22\t17083847\t4.00811\t0.000387462396\n"
+      "chr22\t17084018\t1.91398e-06\t0.001072849206\n"
+      "chr22\t17084051\t1.91398e-06\t0.001072849\n"
+      "chr22\t17084146\t0\t0.001072849\n";
+  igp::interpolator ip;
+  ip.interpolate(_in_query_tmpfile, "bed", _in_gmap_tmpfile, "bedgraph",
+                 _out_tmpfile, "bolt", false, 0.0, false);
+  EXPECT_TRUE(boost::filesystem::exists(_out_tmpfile));
+  std::string observed_output = load_plaintext_file(_out_tmpfile);
+  EXPECT_EQ(expected_output, observed_output);
+}

--- a/interpolate-genetic-position/input_variant_file.cc
+++ b/interpolate-genetic-position/input_variant_file.cc
@@ -23,6 +23,16 @@ igp::vardata::vardata(const vardata &obj)
 
 igp::vardata::~vardata() throw() {}
 
+igp::vardata &igp::vardata::operator=(const igp::vardata &obj) {
+  set_chr(obj.get_chr());
+  set_pos1(obj.get_pos1());
+  set_pos2(obj.get_pos2());
+  set_a1(obj.get_a1());
+  set_a2(obj.get_a2());
+  set_varid(obj.get_varid());
+  return *this;
+}
+
 const std::string &igp::vardata::get_chr() const { return _chr; }
 
 void igp::vardata::set_chr(const std::string &chr) { _chr = chr; }
@@ -62,7 +72,8 @@ igp::input_variant_file::input_variant_file()
       _pos2_index(-1),
       _gpos_index(0),
       _base0(false),
-      _vcf_eof(false) {
+      _vcf_eof(false),
+      _buffer_full(false) {
   _buffer = new char[_buffer_size];
 }
 

--- a/interpolate-genetic-position/input_variant_file.cc
+++ b/interpolate-genetic-position/input_variant_file.cc
@@ -11,13 +11,7 @@
 namespace igp = interpolate_genetic_position;
 
 igp::vardata::vardata()
-    : _chr(""),
-      _varid(""),
-      _pos1(-1),
-      _pos2(-1),
-      _a1(""),
-      _a2(""),
-      _annotation("") {}
+    : _chr(""), _varid(""), _pos1(-1), _pos2(-1), _a1(""), _a2("") {}
 
 igp::vardata::vardata(const vardata &obj)
     : _chr(obj._chr),
@@ -25,8 +19,7 @@ igp::vardata::vardata(const vardata &obj)
       _pos1(obj._pos1),
       _pos2(obj._pos2),
       _a1(obj._a1),
-      _a2(obj._a2),
-      _annotation(obj._annotation) {}
+      _a2(obj._a2) {}
 
 igp::vardata::~vardata() throw() {}
 
@@ -37,7 +30,6 @@ igp::vardata &igp::vardata::operator=(const igp::vardata &obj) {
   set_a1(obj.get_a1());
   set_a2(obj.get_a2());
   set_varid(obj.get_varid());
-  set_annotation(obj.get_annotation());
   return *this;
 }
 
@@ -65,12 +57,6 @@ const std::string &igp::vardata::get_a2() const { return _a2; }
 
 void igp::vardata::set_a2(const std::string &a2) { _a2 = a2; }
 
-const std::string &igp::vardata::get_annotation() const { return _annotation; }
-
-void igp::vardata::set_annotation(const std::string &annotation) {
-  _annotation = annotation;
-}
-
 igp::base_input_variant_file::base_input_variant_file() {}
 igp::base_input_variant_file::~base_input_variant_file() throw() {}
 
@@ -85,7 +71,6 @@ igp::input_variant_file::input_variant_file()
       _pos1_index(0),
       _pos2_index(-1),
       _gpos_index(0),
-      _annotation_index(-1),
       _base0(false),
       _vcf_eof(false),
       _buffer_full(false) {
@@ -157,12 +142,11 @@ std::istream *igp::input_variant_file::get_fallback_stream() const {
 
 void igp::input_variant_file::set_format_parameters(
     unsigned chr_index, unsigned pos1_index, int pos2_index,
-    unsigned gpos_index, int annotation_index, bool base0, unsigned n_tokens) {
+    unsigned gpos_index, bool base0, unsigned n_tokens) {
   _chr_index = chr_index;
   _pos1_index = pos1_index;
   _pos2_index = pos2_index;
   _gpos_index = gpos_index;
-  _annotation_index = annotation_index;
   _base0 = base0;
   _line_contents.resize(n_tokens, "");
 }
@@ -234,15 +218,8 @@ bool igp::input_variant_file::get_variant() {
       _currentvar.set_pos2(_currentvar.get_pos2() + 1);
     }
   }
-  // only if the inputs are regions, determine whether
-  // if the input data format has an annotation entry,
-  // store the annotation entry. this is intended to
-  // be column 4 of bedfile queries
-  if (_annotation_index >= 0) {
-    _currentvar.set_annotation(
-        _line_contents.at(static_cast<unsigned>(_annotation_index)));
-  }
 
+  // now, only if the inputs are regions, determine whether
   // the buffered and current variants are on the same chromosome
   // but not contiguous, and if so, create a fake query that fills
   // that non-contiguous region
@@ -282,10 +259,6 @@ const std::string &igp::input_variant_file::get_a1() const {
 
 const std::string &igp::input_variant_file::get_a2() const {
   return _currentvar.get_a2();
-}
-
-const std::string &igp::input_variant_file::get_annotation() const {
-  return _currentvar.get_annotation();
 }
 
 const std::vector<std::string> &igp::input_variant_file::get_line_contents()

--- a/interpolate-genetic-position/input_variant_file.h
+++ b/interpolate-genetic-position/input_variant_file.h
@@ -113,25 +113,14 @@ class vardata {
    * \param a2 second allele
    */
   void set_a2(const std::string &a2);
-  /*!
-   * \brief get annotation
-   * \return annotation
-   */
-  const std::string &get_annotation() const;
-  /*!
-   * \brief set annotation
-   * \param annotation annotation
-   */
-  void set_annotation(const std::string &annotation);
 
  private:
-  std::string _chr;         //!< chromosome of current marker
-  std::string _varid;       //!< ID of current marker
-  mpz_class _pos1;          //!< physical position of current marker
-  mpz_class _pos2;          //!< for e.g. bedfiles, end position of region
-  std::string _a1;          //!< first allele of current marker
-  std::string _a2;          //!< second allele of current marker
-  std::string _annotation;  //!< variant annotation
+  std::string _chr;    //!< chromosome of current marker
+  std::string _varid;  //!< ID of current marker
+  mpz_class _pos1;     //!< physical position of current marker
+  mpz_class _pos2;     //!< for e.g. bedfiles, end position of region
+  std::string _a1;     //!< first allele of current marker
+  std::string _a2;     //!< second allele of current marker
 };
 /*!
  * \class base_input_variant_file
@@ -179,15 +168,12 @@ class base_input_variant_file {
    * \param pos2_index base 0 index of end position of a region; if not
    * applicable, set negative
    * \param gpos_index base 0 index of genetic position in line tokens
-   * \param annotation_index base 0 index of variant annotation; if not
-   * applicable, set negative
    * \param base0 whether physical position is base 0
    * \param n_tokens expected number of tokens in line
    */
   virtual void set_format_parameters(unsigned chr_index, unsigned pos1_index,
                                      int pos2_index, unsigned gpos_index,
-                                     int annotation_index, bool base0,
-                                     unsigned n_tokens) = 0;
+                                     bool base0, unsigned n_tokens) = 0;
   /*!
    * \brief get next marker's metadata from input connection
    * \return whether a variant was successfully accessed from file
@@ -229,13 +215,6 @@ class base_input_variant_file {
    * at time of writing, only used for vcfs
    */
   virtual const std::string &get_a2() const = 0;
-  /*!
-   * \brief get variant annotation
-   * \return variant annotation
-   *
-   * at time of writing, only used for bedfiles
-   */
-  virtual const std::string &get_annotation() const = 0;
   /*!
    * \brief get vector containing tokenized representation of current line
    * \return vector containing tokenized representation of current line
@@ -296,14 +275,11 @@ class input_variant_file : public base_input_variant_file {
    * \param pos2_index base 0 index of end position of a region; if not
    * applicable, set negative
    * \param gpos_index base 0 index of genetic position in line tokens
-   * \param annotation_index base 0 index of variant annotation; if not
-   * applicable, set negative
    * \param base0 whether physical position is base 0
    * \param n_tokens expected number of tokens in line
    */
   void set_format_parameters(unsigned chr_index, unsigned pos1_index,
-                             int pos2_index, unsigned gpos_index,
-                             int annotation_index, bool base0,
+                             int pos2_index, unsigned gpos_index, bool base0,
                              unsigned n_tokens);
   /*!
    * \brief get next marker's metadata from input connection
@@ -347,13 +323,6 @@ class input_variant_file : public base_input_variant_file {
    */
   const std::string &get_a2() const;
   /*!
-   * \brief get variant annotation
-   * \return variant annotation
-   *
-   * at time of writing, only used for bedfiles
-   */
-  const std::string &get_annotation() const;
-  /*!
    * \brief get vector containing tokenized representation of current line
    * \return vector containing tokenized representation of current line
    */
@@ -377,12 +346,11 @@ class input_variant_file : public base_input_variant_file {
   unsigned _pos1_index;  //!< index of physical position in line
   int _pos2_index;       //!< for e.g. bedfiles, index of end position of region
   unsigned _gpos_index;  //!< index of genetic position in line
-  int _annotation_index;  //!< for e.g. bedfiles, variant annotation
-  vardata _currentvar;    //!< stored information for current query
-  vardata _bufferedvar;   //!< stored information for buffered query
-  bool _base0;            //!< whether physical position is base 0
-  bool _vcf_eof;          //!< track whether vcf eof has been encountered
-  bool _buffer_full;      //!< track whether there is a buffered variant
+  vardata _currentvar;   //!< stored information for current query
+  vardata _bufferedvar;  //!< stored information for buffered query
+  bool _base0;           //!< whether physical position is base 0
+  bool _vcf_eof;         //!< track whether vcf eof has been encountered
+  bool _buffer_full;     //!< track whether there is a buffered variant
 };
 
 }  // namespace interpolate_genetic_position

--- a/interpolate-genetic-position/input_variant_file.h
+++ b/interpolate-genetic-position/input_variant_file.h
@@ -42,6 +42,12 @@ class vardata {
    */
   ~vardata() throw();
   /*!
+   * \brief assignment operator
+   * \param obj value to copy into *this
+   * \return reference to this object
+   */
+  vardata &operator=(const vardata &obj);
+  /*!
    * \brief get chromosome of currently loaded marker
    * \return chromosome of currently loaded marker
    */
@@ -344,6 +350,7 @@ class input_variant_file : public base_input_variant_file {
   vardata _bufferedvar;  //!< stored information for buffered query
   bool _base0;           //!< whether physical position is base 0
   bool _vcf_eof;         //!< track whether vcf eof has been encountered
+  bool _buffer_full;     //!< track whether there is a buffered variant
 };
 
 }  // namespace interpolate_genetic_position

--- a/interpolate-genetic-position/input_variant_file.h
+++ b/interpolate-genetic-position/input_variant_file.h
@@ -113,14 +113,25 @@ class vardata {
    * \param a2 second allele
    */
   void set_a2(const std::string &a2);
+  /*!
+   * \brief get annotation
+   * \return annotation
+   */
+  const std::string &get_annotation() const;
+  /*!
+   * \brief set annotation
+   * \param annotation annotation
+   */
+  void set_annotation(const std::string &annotation);
 
  private:
-  std::string _chr;    //!< chromosome of current marker
-  std::string _varid;  //!< ID of current marker
-  mpz_class _pos1;     //!< physical position of current marker
-  mpz_class _pos2;     //!< for e.g. bedfiles, end position of region
-  std::string _a1;     //!< first allele of current marker
-  std::string _a2;     //!< second allele of current marker
+  std::string _chr;         //!< chromosome of current marker
+  std::string _varid;       //!< ID of current marker
+  mpz_class _pos1;          //!< physical position of current marker
+  mpz_class _pos2;          //!< for e.g. bedfiles, end position of region
+  std::string _a1;          //!< first allele of current marker
+  std::string _a2;          //!< second allele of current marker
+  std::string _annotation;  //!< variant annotation
 };
 /*!
  * \class base_input_variant_file
@@ -168,12 +179,15 @@ class base_input_variant_file {
    * \param pos2_index base 0 index of end position of a region; if not
    * applicable, set negative
    * \param gpos_index base 0 index of genetic position in line tokens
+   * \param annotation_index base 0 index of variant annotation; if not
+   * applicable, set negative
    * \param base0 whether physical position is base 0
    * \param n_tokens expected number of tokens in line
    */
   virtual void set_format_parameters(unsigned chr_index, unsigned pos1_index,
                                      int pos2_index, unsigned gpos_index,
-                                     bool base0, unsigned n_tokens) = 0;
+                                     int annotation_index, bool base0,
+                                     unsigned n_tokens) = 0;
   /*!
    * \brief get next marker's metadata from input connection
    * \return whether a variant was successfully accessed from file
@@ -215,6 +229,13 @@ class base_input_variant_file {
    * at time of writing, only used for vcfs
    */
   virtual const std::string &get_a2() const = 0;
+  /*!
+   * \brief get variant annotation
+   * \return variant annotation
+   *
+   * at time of writing, only used for bedfiles
+   */
+  virtual const std::string &get_annotation() const = 0;
   /*!
    * \brief get vector containing tokenized representation of current line
    * \return vector containing tokenized representation of current line
@@ -275,11 +296,14 @@ class input_variant_file : public base_input_variant_file {
    * \param pos2_index base 0 index of end position of a region; if not
    * applicable, set negative
    * \param gpos_index base 0 index of genetic position in line tokens
+   * \param annotation_index base 0 index of variant annotation; if not
+   * applicable, set negative
    * \param base0 whether physical position is base 0
    * \param n_tokens expected number of tokens in line
    */
   void set_format_parameters(unsigned chr_index, unsigned pos1_index,
-                             int pos2_index, unsigned gpos_index, bool base0,
+                             int pos2_index, unsigned gpos_index,
+                             int annotation_index, bool base0,
                              unsigned n_tokens);
   /*!
    * \brief get next marker's metadata from input connection
@@ -323,6 +347,13 @@ class input_variant_file : public base_input_variant_file {
    */
   const std::string &get_a2() const;
   /*!
+   * \brief get variant annotation
+   * \return variant annotation
+   *
+   * at time of writing, only used for bedfiles
+   */
+  const std::string &get_annotation() const;
+  /*!
    * \brief get vector containing tokenized representation of current line
    * \return vector containing tokenized representation of current line
    */
@@ -346,11 +377,12 @@ class input_variant_file : public base_input_variant_file {
   unsigned _pos1_index;  //!< index of physical position in line
   int _pos2_index;       //!< for e.g. bedfiles, index of end position of region
   unsigned _gpos_index;  //!< index of genetic position in line
-  vardata _currentvar;   //!< stored information for current query
-  vardata _bufferedvar;  //!< stored information for buffered query
-  bool _base0;           //!< whether physical position is base 0
-  bool _vcf_eof;         //!< track whether vcf eof has been encountered
-  bool _buffer_full;     //!< track whether there is a buffered variant
+  int _annotation_index;  //!< for e.g. bedfiles, variant annotation
+  vardata _currentvar;    //!< stored information for current query
+  vardata _bufferedvar;   //!< stored information for buffered query
+  bool _base0;            //!< whether physical position is base 0
+  bool _vcf_eof;          //!< track whether vcf eof has been encountered
+  bool _buffer_full;      //!< track whether there is a buffered variant
 };
 
 }  // namespace interpolate_genetic_position

--- a/interpolate-genetic-position/input_variant_file.h
+++ b/interpolate-genetic-position/input_variant_file.h
@@ -24,6 +24,99 @@
 
 namespace interpolate_genetic_position {
 /*!
+ * @class vardata
+ * @brief store variant metadata
+ */
+class vardata {
+ public:
+  /*!
+   * \brief basic constructor
+   */
+  vardata();
+  /*!
+   * \brief copy constructor
+   */
+  vardata(const vardata &obj);
+  /*!
+   * \brief destructor
+   */
+  ~vardata() throw();
+  /*!
+   * \brief get chromosome of currently loaded marker
+   * \return chromosome of currently loaded marker
+   */
+  const std::string &get_chr() const;
+  /*!
+   * \brief set chromosome of currently loaded marker
+   * \param chr chromosome of currently loaded marker
+   */
+  void set_chr(const std::string &chr);
+  /*!
+   * \brief get physical position of currently loaded marker
+   * \return physical position of currently loaded marker
+   */
+  const mpz_class &get_pos1() const;
+  /*!
+   * \brief set physical position of currently loaded marker
+   * \param pos1 physical position of currently loaded marker
+   */
+  void set_pos1(const mpz_class &pos1);
+  /*!
+   * \brief for region data, get end position of current region
+   * \return end position of current region
+   */
+  const mpz_class &get_pos2() const;
+  /*!
+   * \brief for region data, set end position of current region
+   * \param pos2 end position of current region
+   */
+  void set_pos2(const mpz_class &pos2);
+  /*!
+   * \brief get variant ID
+   * \return variant ID
+   *
+   * at time of writing, only used for vcfs
+   */
+  const std::string &get_varid() const;
+  /*!
+   * \brief set variant ID
+   * \param varid variant ID
+   */
+  void set_varid(const std::string &varid);
+  /*!
+   * \brief get first allele
+   * \return first allele
+   *
+   * at time of writing, only used for vcfs
+   */
+  const std::string &get_a1() const;
+  /*!
+   * \brief set first allele
+   * \param a1 first allele
+   */
+  void set_a1(const std::string &a1);
+  /*!
+   * \brief get second allele
+   * \return second allele
+   *
+   * at time of writing, only used for vcfs
+   */
+  const std::string &get_a2() const;
+  /*!
+   * \brief set second allele
+   * \param a2 second allele
+   */
+  void set_a2(const std::string &a2);
+
+ private:
+  std::string _chr;    //!< chromosome of current marker
+  std::string _varid;  //!< ID of current marker
+  mpz_class _pos1;     //!< physical position of current marker
+  mpz_class _pos2;     //!< for e.g. bedfiles, end position of region
+  std::string _a1;     //!< first allele of current marker
+  std::string _a2;     //!< second allele of current marker
+};
+/*!
  * \class base_input_variant_file
  * \brief virtual base class for input variant file types;
  * split out in this manner to facilitate mocks.
@@ -247,15 +340,12 @@ class input_variant_file : public base_input_variant_file {
   unsigned _pos1_index;  //!< index of physical position in line
   int _pos2_index;       //!< for e.g. bedfiles, index of end position of region
   unsigned _gpos_index;  //!< index of genetic position in line
-  std::string _chr;      //!< chromosome of current marker
-  std::string _varid;    //!< ID of current marker
-  mpz_class _pos1;       //!< physical position of current marker
-  mpz_class _pos2;       //!< for e.g. bedfiles, end position of region
-  std::string _a1;       //!< first allele of current marker
-  std::string _a2;       //!< second allele of current marker
+  vardata _currentvar;   //!< stored information for current query
+  vardata _bufferedvar;  //!< stored information for buffered query
   bool _base0;           //!< whether physical position is base 0
   bool _vcf_eof;         //!< track whether vcf eof has been encountered
 };
+
 }  // namespace interpolate_genetic_position
 
 #endif  // INTERPOLATE_GENETIC_POSITION_INPUT_VARIANT_FILE_H_

--- a/interpolate-genetic-position/output_variant_file.cc
+++ b/interpolate-genetic-position/output_variant_file.cc
@@ -21,7 +21,8 @@ igp::output_variant_file::output_variant_file()
       _last_pos1(0),
       _last_pos2(0),
       _last_gpos(0.0),
-      _last_rate(0.0) {}
+      _last_rate(0.0),
+      _step_interval(0.0) {}
 
 igp::output_variant_file::~output_variant_file() throw() { close(); }
 
@@ -78,11 +79,12 @@ void igp::output_variant_file::close() {
 void igp::output_variant_file::write(
     const std::string &chr, const mpz_class &pos1, const mpz_class &pos2,
     const std::string &id, const mpf_class &gpos, const mpf_class &rate,
-    const std::string &a1, const std::string &a2, const double &step_interval) {
+    const std::string &a1, const std::string &a2) {
   // the idea is: format an output line, then emit it to appropriate target
   std::ostringstream out;
   format_type ft = get_format();
   mpf_class output_gpos = output_morgans() ? gpos / mpf_class("100") : gpos;
+  mpf_class step_interval = get_step_interval();
   // track when a result is on a different chromosome than the previous ones
   if (get_last_chr().compare(chr)) {
     // for bolt output only, emit dummy results at the end of a chromosome
@@ -162,4 +164,13 @@ mpz_class igp::output_variant_file::get_last_pos2() const { return _last_pos2; }
 
 void igp::output_variant_file::set_last_pos2(const mpz_class &pos2) {
   _last_pos2 = pos2;
+}
+
+const mpf_class &igp::output_variant_file::get_step_interval() const {
+  return _step_interval;
+}
+
+void igp::output_variant_file::set_step_interval(
+    const mpf_class &step_interval) {
+  _step_interval = step_interval;
 }

--- a/interpolate-genetic-position/output_variant_file.cc
+++ b/interpolate-genetic-position/output_variant_file.cc
@@ -53,6 +53,23 @@ void igp::output_variant_file::open(const std::string &filename,
 
 void igp::output_variant_file::close() {
   if (_output.is_open()) {
+    // only for BOLT output: make sure the end of the last chromosome has
+    // a placeholder entry with 0 rate
+    if (get_format() == BOLT && cmp(get_last_rate(), 0) != 0) {
+      std::ostringstream out;
+      out << get_last_chr() << '\t' << get_last_pos2() << '\t' << "0\t"
+          << (get_last_gpos() + get_last_rate() *
+                                    (get_last_pos2() - get_last_pos1()) /
+                                    mpf_class(1000000.0));
+      if (_output.is_open()) {
+        if (!(_output << out.str() << '\n')) {
+          throw std::runtime_error(
+              "output_variant_file::write: cannot write to file");
+        }
+      } else {
+        std::cout << out.str() << '\n';
+      }
+    }
     _output.close();
     _output.clear();
   }

--- a/interpolate-genetic-position/output_variant_file.cc
+++ b/interpolate-genetic-position/output_variant_file.cc
@@ -59,9 +59,10 @@ void igp::output_variant_file::close() {
     if (get_format() == BOLT && cmp(get_last_rate(), 0) != 0) {
       std::ostringstream out;
       out << get_last_chr() << '\t' << get_last_pos2() << '\t' << "0\t"
-          << (get_last_gpos() + get_last_rate() *
-                                    (get_last_pos2() - get_last_pos1()) /
-                                    mpf_class(1000000.0));
+          << (get_last_gpos() +
+              get_last_rate() * (get_last_pos2() - get_last_pos1()) /
+                  mpf_class(1000000.0) +
+              get_step_interval());
       if (_output.is_open()) {
         if (!(_output << out.str() << '\n')) {
           throw std::runtime_error(

--- a/interpolate-genetic-position/output_variant_file.h
+++ b/interpolate-genetic-position/output_variant_file.h
@@ -53,8 +53,7 @@ class base_output_variant_file {
   virtual void write(const std::string &chr, const mpz_class &pos1,
                      const mpz_class &pos2, const std::string &id,
                      const mpf_class &gpos, const mpf_class &rate,
-                     const std::string &a1, const std::string &a2,
-                     const double &step_interval) = 0;
+                     const std::string &a1, const std::string &a2) = 0;
   /*!
    * \brief get descriptor of format of output file
    * \return output file format
@@ -142,6 +141,16 @@ class base_output_variant_file {
    * emitted result
    */
   virtual void set_last_rate(const mpf_class &rate) = 0;
+  /*!
+   * \brief get the experimental step interval at region boundaries
+   * \return the experimental step interval at region boundaries
+   */
+  virtual const mpf_class &get_step_interval() const = 0;
+  /*!
+   * \brief set the experimental step interval at region boundaries
+   * \param step_interval the experimental step interval
+   */
+  virtual void set_step_interval(const mpf_class &step_interval) = 0;
 };
 
 /*!
@@ -176,8 +185,7 @@ class output_variant_file : public base_output_variant_file {
   void write(const std::string &chr, const mpz_class &pos1,
              const mpz_class &pos2, const std::string &id,
              const mpf_class &gpos, const mpf_class &rate,
-             const std::string &a1, const std::string &a2,
-             const double &step_interval);
+             const std::string &a1, const std::string &a2);
   /*!
    * \brief get descriptor of format of output file
    * \return output file format
@@ -265,16 +273,27 @@ class output_variant_file : public base_output_variant_file {
    * emitted result
    */
   void set_last_rate(const mpf_class &rate);
+  /*!
+   * \brief get the experimental step interval at region boundaries
+   * \return the experimental step interval at region boundaries
+   */
+  const mpf_class &get_step_interval() const;
+  /*!
+   * \brief set the experimental step interval at region boundaries
+   * \param step_interval the experimental step interval
+   */
+  void set_step_interval(const mpf_class &step_interval);
 
  private:
-  std::ofstream _output;  //!< output uncompressed file stream
-  format_type _ft;        //!< format of output file
-  bool _output_morgans;   //!< whether to emit genetic position as morgans
-  std::string _last_chr;  //!< chromosome of most recently emitted result
-  mpz_class _last_pos1;   //!< start position of most recent result
-  mpz_class _last_pos2;   //!< end position of most recent result
-  mpf_class _last_gpos;   //!< genetic position of most recent result
-  mpf_class _last_rate;   //!< rate of most recent result
+  std::ofstream _output;     //!< output uncompressed file stream
+  format_type _ft;           //!< format of output file
+  bool _output_morgans;      //!< whether to emit genetic position as morgans
+  std::string _last_chr;     //!< chromosome of most recently emitted result
+  mpz_class _last_pos1;      //!< start position of most recent result
+  mpz_class _last_pos2;      //!< end position of most recent result
+  mpf_class _last_gpos;      //!< genetic position of most recent result
+  mpf_class _last_rate;      //!< rate of most recent result
+  mpf_class _step_interval;  //!< gpos increment to edge of bed queries
 };
 }  // namespace interpolate_genetic_position
 

--- a/interpolate-genetic-position/output_variant_file.h
+++ b/interpolate-genetic-position/output_variant_file.h
@@ -151,6 +151,18 @@ class base_output_variant_file {
    * \param step_interval the experimental step interval
    */
   virtual void set_step_interval(const mpf_class &step_interval) = 0;
+  /*!
+   * \brief get the index of this result among results
+   * for this chromosome
+   * \return index of this result
+   */
+  virtual unsigned get_index_on_chromosome() const = 0;
+  /*!
+   * \brief set the index of this result among results
+   * for this chromosome
+   * \param index index of this result
+   */
+  virtual void set_index_on_chromosome(unsigned index) = 0;
 };
 
 /*!
@@ -283,6 +295,18 @@ class output_variant_file : public base_output_variant_file {
    * \param step_interval the experimental step interval
    */
   void set_step_interval(const mpf_class &step_interval);
+  /*!
+   * \brief get the index of this result among results
+   * for this chromosome
+   * \return index of this result
+   */
+  unsigned get_index_on_chromosome() const;
+  /*!
+   * \brief set the index of this result among results
+   * for this chromosome
+   * \param index index of this result
+   */
+  void set_index_on_chromosome(unsigned index);
 
  private:
   std::ofstream _output;     //!< output uncompressed file stream
@@ -294,6 +318,8 @@ class output_variant_file : public base_output_variant_file {
   mpf_class _last_gpos;      //!< genetic position of most recent result
   mpf_class _last_rate;      //!< rate of most recent result
   mpf_class _step_interval;  //!< gpos increment to edge of bed queries
+  unsigned _index_on_chromosome;  //!< how many queries have been returned on
+                                  //!< this chromosome
 };
 }  // namespace interpolate_genetic_position
 

--- a/interpolate-genetic-position/query_file.cc
+++ b/interpolate-genetic-position/query_file.cc
@@ -19,10 +19,7 @@ igp::query_file::query_file(const query_file &obj) {
 }
 igp::query_file::query_file(base_input_variant_file *inptr,
                             base_output_variant_file *outptr)
-    : _interface(inptr),
-      _ft(UNKNOWN),
-      _output(outptr),
-      _index_on_chromosome(0) {}
+    : _interface(inptr), _ft(UNKNOWN), _output(outptr) {}
 igp::query_file::~query_file() throw() {}
 void igp::query_file::open(const std::string &filename, format_type ft) {
   _ft = ft;
@@ -63,7 +60,6 @@ bool igp::query_file::eof() { return _interface->eof(); }
 void igp::query_file::report(const std::vector<query_result> &results) {
   std::string id = "", a1 = "", a2 = "";
   if (get_previous_chromosome().compare(results.begin()->get_chr())) {
-    set_index_on_chromosome(0);
     set_previous_chromosome(results.begin()->get_chr());
   }
   for (std::vector<query_result>::const_iterator iter = results.begin();
@@ -80,14 +76,10 @@ void igp::query_file::report(const std::vector<query_result> &results) {
       a1 = _interface->get_a1();
       a2 = _interface->get_a2();
     }
-    _output->write(
-        iter->get_chr(), iter->get_startpos(), iter->get_endpos(), id,
-        iter->get_gpos() +
-            (_ft == BED ? get_step_interval() * get_index_on_chromosome()
-                        : mpf_class("0.0")),
-        iter->get_rate(), a1, a2);
+    _output->write(iter->get_chr(), iter->get_startpos(), iter->get_endpos(),
+                   id, iter->get_gpos(), iter->get_rate(), a1, a2);
   }
-  set_index_on_chromosome(get_index_on_chromosome() + 1);
+  _output->set_index_on_chromosome(_output->get_index_on_chromosome() + 1);
 }
 const mpf_class &igp::query_file::get_step_interval() const {
   if (_output) {
@@ -103,12 +95,6 @@ void igp::query_file::set_step_interval(const mpf_class &step) {
   }
   throw std::runtime_error(
       "query_file::set_step_interval: called on unset output");
-}
-unsigned igp::query_file::get_index_on_chromosome() const {
-  return _index_on_chromosome;
-}
-void igp::query_file::set_index_on_chromosome(unsigned index) {
-  _index_on_chromosome = index;
 }
 const std::string &igp::query_file::get_previous_chromosome() const {
   return _previous_chromosome;

--- a/interpolate-genetic-position/query_file.cc
+++ b/interpolate-genetic-position/query_file.cc
@@ -29,16 +29,16 @@ void igp::query_file::open(const std::string &filename, format_type ft) {
   _interface->open(filename);
   // handle file formats
   if (_ft == BIM) {
-    _interface->set_format_parameters(0, 3, -1, 2, false, 6);
+    _interface->set_format_parameters(0, 3, -1, 2, -1, false, 6);
   } else if (_ft == MAP) {
-    _interface->set_format_parameters(0, 3, -1, 2, false, 4);
+    _interface->set_format_parameters(0, 3, -1, 2, -1, false, 4);
   } else if (_ft == BED) {
-    _interface->set_format_parameters(0, 1, 2, 4, true, 4);
+    _interface->set_format_parameters(0, 1, 2, 4, 3, true, 4);
   } else if (_ft == SNP) {
-    _interface->set_format_parameters(1, 3, -1, 2, false, 4);
+    _interface->set_format_parameters(1, 3, -1, 2, -1, false, 4);
   } else if (_ft == VCF) {
     // these are ignored due to use of htslib
-    _interface->set_format_parameters(0, 1, -1, -1, false, 9);
+    _interface->set_format_parameters(0, 1, -1, -1, -1, false, 9);
   }
 }
 void igp::query_file::initialize_output(const std::string &filename,

--- a/interpolate-genetic-position/query_file.cc
+++ b/interpolate-genetic-position/query_file.cc
@@ -22,7 +22,6 @@ igp::query_file::query_file(base_input_variant_file *inptr,
     : _interface(inptr),
       _ft(UNKNOWN),
       _output(outptr),
-      _step_interval(0.0),
       _index_on_chromosome(0) {}
 igp::query_file::~query_file() throw() {}
 void igp::query_file::open(const std::string &filename, format_type ft) {
@@ -85,16 +84,25 @@ void igp::query_file::report(const std::vector<query_result> &results) {
         iter->get_chr(), iter->get_startpos(), iter->get_endpos(), id,
         iter->get_gpos() +
             (_ft == BED ? get_step_interval() * get_index_on_chromosome()
-                        : 0.0),
-        iter->get_rate(), a1, a2, get_step_interval());
+                        : mpf_class("0.0")),
+        iter->get_rate(), a1, a2);
   }
   set_index_on_chromosome(get_index_on_chromosome() + 1);
 }
-const double &igp::query_file::get_step_interval() const {
-  return _step_interval;
+const mpf_class &igp::query_file::get_step_interval() const {
+  if (_output) {
+    return _output->get_step_interval();
+  }
+  throw std::runtime_error(
+      "query_file::get_step_interval: called on unset output");
 }
-void igp::query_file::set_step_interval(const double &step) {
-  _step_interval = step;
+void igp::query_file::set_step_interval(const mpf_class &step) {
+  if (_output) {
+    _output->set_step_interval(step);
+    return;
+  }
+  throw std::runtime_error(
+      "query_file::set_step_interval: called on unset output");
 }
 unsigned igp::query_file::get_index_on_chromosome() const {
   return _index_on_chromosome;

--- a/interpolate-genetic-position/query_file.cc
+++ b/interpolate-genetic-position/query_file.cc
@@ -30,16 +30,16 @@ void igp::query_file::open(const std::string &filename, format_type ft) {
   _interface->open(filename);
   // handle file formats
   if (_ft == BIM) {
-    _interface->set_format_parameters(0, 3, -1, 2, -1, false, 6);
+    _interface->set_format_parameters(0, 3, -1, 2, false, 6);
   } else if (_ft == MAP) {
-    _interface->set_format_parameters(0, 3, -1, 2, -1, false, 4);
+    _interface->set_format_parameters(0, 3, -1, 2, false, 4);
   } else if (_ft == BED) {
-    _interface->set_format_parameters(0, 1, 2, 4, 3, true, 4);
+    _interface->set_format_parameters(0, 1, 2, 4, true, 4);
   } else if (_ft == SNP) {
-    _interface->set_format_parameters(1, 3, -1, 2, -1, false, 4);
+    _interface->set_format_parameters(1, 3, -1, 2, false, 4);
   } else if (_ft == VCF) {
     // these are ignored due to use of htslib
-    _interface->set_format_parameters(0, 1, -1, -1, -1, false, 9);
+    _interface->set_format_parameters(0, 1, -1, -1, false, 9);
   }
 }
 void igp::query_file::initialize_output(const std::string &filename,

--- a/interpolate-genetic-position/query_file.h
+++ b/interpolate-genetic-position/query_file.h
@@ -100,12 +100,12 @@ class query_file {
    * \brief get the fixed interval to add to output
    * \return fixed interval to add to output
    */
-  const double &get_step_interval() const;
+  const mpf_class &get_step_interval() const;
   /*!
    * \brief set the fixed interval to add to output
    * \param step fixed interval to add to output
    */
-  void set_step_interval(const double &step);
+  void set_step_interval(const mpf_class &step);
   /*!
    * \brief get the index of this result among results
    * for this chromosome
@@ -151,9 +151,8 @@ class query_file {
   base_input_variant_file *_interface;  //!< input file handler
   format_type _ft;                      //!< stored format of input filestream
   base_output_variant_file *_output;    //!< interface class to output
-  double _step_interval;          //!< fixed genetic distance to add to interval
-  unsigned _index_on_chromosome;  //!< how many queries have been returned on
-                                  //!< this chromosome
+  unsigned _index_on_chromosome;     //!< how many queries have been returned on
+                                     //!< this chromosome
   std::string _previous_chromosome;  //!< name of chromosome for prior output
 };
 }  // namespace interpolate_genetic_position

--- a/interpolate-genetic-position/query_file.h
+++ b/interpolate-genetic-position/query_file.h
@@ -117,6 +117,16 @@ class query_file {
    */
   void set_previous_chromosome(const std::string &chr);
   /*!
+   * \brief get label (column 4) of previous bed file query
+   * \return label (column 4) of previous bed file query
+   */
+  const std::string &get_previous_bed_label() const;
+  /*!
+   * \brief set label (column 4) of previous bed file query
+   * \param label label (column 4) of previous bed file query
+   */
+  void set_previous_bed_label(const std::string &label);
+  /*!
    * \brief close any input connection
    */
   void close();
@@ -140,6 +150,7 @@ class query_file {
   format_type _ft;                      //!< stored format of input filestream
   base_output_variant_file *_output;    //!< interface class to output
   std::string _previous_chromosome;     //!< name of chromosome for prior output
+  std::string _previous_bed_label;      //!< label of previous bed format query
 };
 }  // namespace interpolate_genetic_position
 

--- a/interpolate-genetic-position/query_file.h
+++ b/interpolate-genetic-position/query_file.h
@@ -107,18 +107,6 @@ class query_file {
    */
   void set_step_interval(const mpf_class &step);
   /*!
-   * \brief get the index of this result among results
-   * for this chromosome
-   * \return index of this result
-   */
-  unsigned get_index_on_chromosome() const;
-  /*!
-   * \brief set the index of this result among results
-   * for this chromosome
-   * \param index index of this result
-   */
-  void set_index_on_chromosome(unsigned index);
-  /*!
    * \brief get identifier of previous output result
    * \return identifier of previous output result
    */
@@ -151,9 +139,7 @@ class query_file {
   base_input_variant_file *_interface;  //!< input file handler
   format_type _ft;                      //!< stored format of input filestream
   base_output_variant_file *_output;    //!< interface class to output
-  unsigned _index_on_chromosome;     //!< how many queries have been returned on
-                                     //!< this chromosome
-  std::string _previous_chromosome;  //!< name of chromosome for prior output
+  std::string _previous_chromosome;     //!< name of chromosome for prior output
 };
 }  // namespace interpolate_genetic_position
 

--- a/test_command.bash
+++ b/test_command.bash
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-./interpolate-genetic-position.out  -i ~/Development/snakemake-interpolate-genetic-position/resources/hapmap_CEU_r23a_filtered.bim -p bim -g ~/Development/snakemake-interpolate-genetic-position/results/interpolate-genetic-position/recombination_maps/bolt/BOLT-LMM_v2.4.1/tables/genetic_map_hg18_withX.txt.gz -m bolt -o tmp.bim

--- a/unit_tests/input_variant_file_test.h
+++ b/unit_tests/input_variant_file_test.h
@@ -35,7 +35,8 @@ class mock_input_variant_file : public base_input_variant_file {
   MOCK_METHOD(std::istream *, get_fallback_stream, (), (const, override));
   MOCK_METHOD(void, set_format_parameters,
               (unsigned chr_index, unsigned pos1_index, int pos2_index,
-               unsigned gpos_index, bool base0, unsigned n_tokens),
+               unsigned gpos_index, int annotation_index, bool base0,
+               unsigned n_tokens),
               (override));
   MOCK_METHOD(bool, get_variant, (), (override));
   MOCK_METHOD(const std::string &, get_chr, (), (const, override));
@@ -44,6 +45,7 @@ class mock_input_variant_file : public base_input_variant_file {
   MOCK_METHOD(const std::string &, get_varid, (), (const, override));
   MOCK_METHOD(const std::string &, get_a1, (), (const, override));
   MOCK_METHOD(const std::string &, get_a2, (), (const, override));
+  MOCK_METHOD(const std::string &, get_annotation, (), (const override));
   MOCK_METHOD(const std::vector<std::string> &, get_line_contents, (),
               (const, override));
   MOCK_METHOD(bool, eof, (), (override));

--- a/unit_tests/input_variant_file_test.h
+++ b/unit_tests/input_variant_file_test.h
@@ -35,8 +35,7 @@ class mock_input_variant_file : public base_input_variant_file {
   MOCK_METHOD(std::istream *, get_fallback_stream, (), (const, override));
   MOCK_METHOD(void, set_format_parameters,
               (unsigned chr_index, unsigned pos1_index, int pos2_index,
-               unsigned gpos_index, int annotation_index, bool base0,
-               unsigned n_tokens),
+               unsigned gpos_index, bool base0, unsigned n_tokens),
               (override));
   MOCK_METHOD(bool, get_variant, (), (override));
   MOCK_METHOD(const std::string &, get_chr, (), (const, override));
@@ -45,7 +44,6 @@ class mock_input_variant_file : public base_input_variant_file {
   MOCK_METHOD(const std::string &, get_varid, (), (const, override));
   MOCK_METHOD(const std::string &, get_a1, (), (const, override));
   MOCK_METHOD(const std::string &, get_a2, (), (const, override));
-  MOCK_METHOD(const std::string &, get_annotation, (), (const override));
   MOCK_METHOD(const std::vector<std::string> &, get_line_contents, (),
               (const, override));
   MOCK_METHOD(bool, eof, (), (override));

--- a/unit_tests/output_variant_file_test.h
+++ b/unit_tests/output_variant_file_test.h
@@ -36,8 +36,7 @@ class mock_output_variant_file : public base_output_variant_file {
               (const std::string &chr, const mpz_class &pos1,
                const mpz_class &pos2, const std::string &id,
                const mpf_class &gpos, const mpf_class &rate,
-               const std::string &a1, const std::string &a2,
-               const double &step_interval),
+               const std::string &a1, const std::string &a2),
               (override));
   MOCK_METHOD(format_type, get_format, (), (const, override));
   MOCK_METHOD(void, output_morgans, (bool use_morgans), (override));
@@ -52,6 +51,8 @@ class mock_output_variant_file : public base_output_variant_file {
   MOCK_METHOD(void, set_last_pos1, (const mpz_class &), (override));
   MOCK_METHOD(mpz_class, get_last_pos2, (), (const, override));
   MOCK_METHOD(void, set_last_pos2, (const mpz_class &), (override));
+  MOCK_METHOD(const mpf_class &, get_step_interval, (), (const, override));
+  MOCK_METHOD(void, set_step_interval, (const mpf_class &), (override));
 };
 }  // namespace interpolate_genetic_position
 #endif  // UNIT_TESTS_OUTPUT_VARIANT_FILE_TEST_H_

--- a/unit_tests/output_variant_file_test.h
+++ b/unit_tests/output_variant_file_test.h
@@ -53,6 +53,8 @@ class mock_output_variant_file : public base_output_variant_file {
   MOCK_METHOD(void, set_last_pos2, (const mpz_class &), (override));
   MOCK_METHOD(const mpf_class &, get_step_interval, (), (const, override));
   MOCK_METHOD(void, set_step_interval, (const mpf_class &), (override));
+  MOCK_METHOD(unsigned, get_index_on_chromosome, (), (const, override));
+  MOCK_METHOD(void, set_index_on_chromosome, (unsigned), (override));
 };
 }  // namespace interpolate_genetic_position
 #endif  // UNIT_TESTS_OUTPUT_VARIANT_FILE_TEST_H_

--- a/unit_tests/query_file_test.cc
+++ b/unit_tests/query_file_test.cc
@@ -98,3 +98,13 @@ TEST(queryFileTest, canReadFromCin) {
   EXPECT_EQ(qf.get_pos2(), mpz_class(-1));
   EXPECT_FALSE(qf.get());
 }
+
+TEST(queryFileTest, preventNullAccessOfStepInterval) {
+  igp::query_file qf(NULL, NULL);
+  EXPECT_THROW(qf.get_step_interval(), std::runtime_error);
+}
+
+TEST(queryFileTest, preventNullSettingOfStepInterval) {
+  igp::query_file qf(NULL, NULL);
+  EXPECT_THROW(qf.set_step_interval(mpf_class(0.0)), std::runtime_error);
+}

--- a/unit_tests/query_file_test.cc
+++ b/unit_tests/query_file_test.cc
@@ -21,7 +21,7 @@ TEST(queryFileTest, canInitializeBimfile) {
   igp::mock_input_variant_file mock_infile;
   igp::mock_output_variant_file mock_outfile;
   std::string bimfilename = "test.bim";
-  EXPECT_CALL(mock_infile, set_format_parameters(0, 3, -1, 2, -1, false, 6))
+  EXPECT_CALL(mock_infile, set_format_parameters(0, 3, -1, 2, false, 6))
       .Times(1)
       .WillOnce(Return());
   EXPECT_CALL(mock_infile, open(bimfilename)).Times(1).WillOnce(Return());
@@ -33,7 +33,7 @@ TEST(queryFileTest, canInitializeMapfile) {
   igp::mock_input_variant_file mock_infile;
   igp::mock_output_variant_file mock_outfile;
   std::string mapfilename = "test.map";
-  EXPECT_CALL(mock_infile, set_format_parameters(0, 3, -1, 2, -1, false, 4))
+  EXPECT_CALL(mock_infile, set_format_parameters(0, 3, -1, 2, false, 4))
       .Times(1)
       .WillOnce(Return());
   EXPECT_CALL(mock_infile, open(mapfilename)).Times(1).WillOnce(Return());
@@ -45,7 +45,7 @@ TEST(queryFileTest, canInitializeBedfile) {
   igp::mock_input_variant_file mock_infile;
   igp::mock_output_variant_file mock_outfile;
   std::string bedfilename = "test.bed";
-  EXPECT_CALL(mock_infile, set_format_parameters(0, 1, 2, 4, 3, true, 4))
+  EXPECT_CALL(mock_infile, set_format_parameters(0, 1, 2, 4, true, 4))
       .Times(1)
       .WillOnce(Return());
   EXPECT_CALL(mock_infile, open(bedfilename)).Times(1).WillOnce(Return());
@@ -57,7 +57,7 @@ TEST(queryFileTest, canInitializeVcf) {
   igp::mock_input_variant_file mock_infile;
   igp::mock_output_variant_file mock_outfile;
   std::string vcfname = "test.vcf";
-  EXPECT_CALL(mock_infile, set_format_parameters(0, 1, -1, -1, -1, false, 9))
+  EXPECT_CALL(mock_infile, set_format_parameters(0, 1, -1, -1, false, 9))
       .Times(1)
       .WillOnce(Return());
   EXPECT_CALL(mock_infile, open(vcfname)).Times(1).WillOnce(Return());

--- a/unit_tests/query_file_test.cc
+++ b/unit_tests/query_file_test.cc
@@ -21,7 +21,7 @@ TEST(queryFileTest, canInitializeBimfile) {
   igp::mock_input_variant_file mock_infile;
   igp::mock_output_variant_file mock_outfile;
   std::string bimfilename = "test.bim";
-  EXPECT_CALL(mock_infile, set_format_parameters(0, 3, -1, 2, false, 6))
+  EXPECT_CALL(mock_infile, set_format_parameters(0, 3, -1, 2, -1, false, 6))
       .Times(1)
       .WillOnce(Return());
   EXPECT_CALL(mock_infile, open(bimfilename)).Times(1).WillOnce(Return());
@@ -33,7 +33,7 @@ TEST(queryFileTest, canInitializeMapfile) {
   igp::mock_input_variant_file mock_infile;
   igp::mock_output_variant_file mock_outfile;
   std::string mapfilename = "test.map";
-  EXPECT_CALL(mock_infile, set_format_parameters(0, 3, -1, 2, false, 4))
+  EXPECT_CALL(mock_infile, set_format_parameters(0, 3, -1, 2, -1, false, 4))
       .Times(1)
       .WillOnce(Return());
   EXPECT_CALL(mock_infile, open(mapfilename)).Times(1).WillOnce(Return());
@@ -45,7 +45,7 @@ TEST(queryFileTest, canInitializeBedfile) {
   igp::mock_input_variant_file mock_infile;
   igp::mock_output_variant_file mock_outfile;
   std::string bedfilename = "test.bed";
-  EXPECT_CALL(mock_infile, set_format_parameters(0, 1, 2, 4, true, 4))
+  EXPECT_CALL(mock_infile, set_format_parameters(0, 1, 2, 4, 3, true, 4))
       .Times(1)
       .WillOnce(Return());
   EXPECT_CALL(mock_infile, open(bedfilename)).Times(1).WillOnce(Return());
@@ -57,7 +57,7 @@ TEST(queryFileTest, canInitializeVcf) {
   igp::mock_input_variant_file mock_infile;
   igp::mock_output_variant_file mock_outfile;
   std::string vcfname = "test.vcf";
-  EXPECT_CALL(mock_infile, set_format_parameters(0, 1, -1, -1, false, 9))
+  EXPECT_CALL(mock_infile, set_format_parameters(0, 1, -1, -1, -1, false, 9))
       .Times(1)
       .WillOnce(Return());
   EXPECT_CALL(mock_infile, open(vcfname)).Times(1).WillOnce(Return());

--- a/unit_tests/vardata_test.cc
+++ b/unit_tests/vardata_test.cc
@@ -20,6 +20,7 @@ TEST(vardataTest, copyConstructor) {
   vd1.set_a1("A");
   vd1.set_a2("T");
   vd1.set_varid("rs1");
+  vd1.set_annotation("annot");
   igp::vardata vd2(vd1);
   EXPECT_EQ(vd1.get_chr(), vd2.get_chr());
   EXPECT_EQ(vd1.get_pos1(), vd2.get_pos1());
@@ -27,6 +28,7 @@ TEST(vardataTest, copyConstructor) {
   EXPECT_EQ(vd1.get_a1(), vd2.get_a1());
   EXPECT_EQ(vd1.get_a2(), vd2.get_a2());
   EXPECT_EQ(vd1.get_varid(), vd2.get_varid());
+  EXPECT_EQ(vd1.get_annotation(), vd2.get_annotation());
 }
 
 TEST(vardataTest, assignmentOperator) {
@@ -37,6 +39,7 @@ TEST(vardataTest, assignmentOperator) {
   vd1.set_a1("A");
   vd1.set_a2("T");
   vd1.set_varid("rs1");
+  vd1.set_annotation("annot");
   igp::vardata vd2 = vd1;
   EXPECT_EQ(vd1.get_chr(), vd2.get_chr());
   EXPECT_EQ(vd1.get_pos1(), vd2.get_pos1());
@@ -44,6 +47,7 @@ TEST(vardataTest, assignmentOperator) {
   EXPECT_EQ(vd1.get_a1(), vd2.get_a1());
   EXPECT_EQ(vd1.get_a2(), vd2.get_a2());
   EXPECT_EQ(vd1.get_varid(), vd2.get_varid());
+  EXPECT_EQ(vd1.get_annotation(), vd2.get_annotation());
 }
 
 TEST(vardataTest, testGetSet) {
@@ -54,10 +58,12 @@ TEST(vardataTest, testGetSet) {
   vd.set_a1("A");
   vd.set_a2("T");
   vd.set_varid("rs1");
+  vd.set_annotation("annot");
   EXPECT_EQ(vd.get_chr(), "chr1");
   EXPECT_EQ(vd.get_pos1(), mpz_class(100));
   EXPECT_EQ(vd.get_pos2(), mpz_class(200));
   EXPECT_EQ(vd.get_a1(), "A");
   EXPECT_EQ(vd.get_a2(), "T");
   EXPECT_EQ(vd.get_varid(), "rs1");
+  EXPECT_EQ(vd.get_annotation(), "annot");
 }

--- a/unit_tests/vardata_test.cc
+++ b/unit_tests/vardata_test.cc
@@ -20,7 +20,6 @@ TEST(vardataTest, copyConstructor) {
   vd1.set_a1("A");
   vd1.set_a2("T");
   vd1.set_varid("rs1");
-  vd1.set_annotation("annot");
   igp::vardata vd2(vd1);
   EXPECT_EQ(vd1.get_chr(), vd2.get_chr());
   EXPECT_EQ(vd1.get_pos1(), vd2.get_pos1());
@@ -28,7 +27,6 @@ TEST(vardataTest, copyConstructor) {
   EXPECT_EQ(vd1.get_a1(), vd2.get_a1());
   EXPECT_EQ(vd1.get_a2(), vd2.get_a2());
   EXPECT_EQ(vd1.get_varid(), vd2.get_varid());
-  EXPECT_EQ(vd1.get_annotation(), vd2.get_annotation());
 }
 
 TEST(vardataTest, assignmentOperator) {
@@ -39,7 +37,6 @@ TEST(vardataTest, assignmentOperator) {
   vd1.set_a1("A");
   vd1.set_a2("T");
   vd1.set_varid("rs1");
-  vd1.set_annotation("annot");
   igp::vardata vd2 = vd1;
   EXPECT_EQ(vd1.get_chr(), vd2.get_chr());
   EXPECT_EQ(vd1.get_pos1(), vd2.get_pos1());
@@ -47,7 +44,6 @@ TEST(vardataTest, assignmentOperator) {
   EXPECT_EQ(vd1.get_a1(), vd2.get_a1());
   EXPECT_EQ(vd1.get_a2(), vd2.get_a2());
   EXPECT_EQ(vd1.get_varid(), vd2.get_varid());
-  EXPECT_EQ(vd1.get_annotation(), vd2.get_annotation());
 }
 
 TEST(vardataTest, testGetSet) {
@@ -58,12 +54,10 @@ TEST(vardataTest, testGetSet) {
   vd.set_a1("A");
   vd.set_a2("T");
   vd.set_varid("rs1");
-  vd.set_annotation("annot");
   EXPECT_EQ(vd.get_chr(), "chr1");
   EXPECT_EQ(vd.get_pos1(), mpz_class(100));
   EXPECT_EQ(vd.get_pos2(), mpz_class(200));
   EXPECT_EQ(vd.get_a1(), "A");
   EXPECT_EQ(vd.get_a2(), "T");
   EXPECT_EQ(vd.get_varid(), "rs1");
-  EXPECT_EQ(vd.get_annotation(), "annot");
 }

--- a/unit_tests/vardata_test.cc
+++ b/unit_tests/vardata_test.cc
@@ -29,6 +29,23 @@ TEST(vardataTest, copyConstructor) {
   EXPECT_EQ(vd1.get_varid(), vd2.get_varid());
 }
 
+TEST(vardataTest, assignmentOperator) {
+  igp::vardata vd1;
+  vd1.set_chr("chr1");
+  vd1.set_pos1(100);
+  vd1.set_pos2(200);
+  vd1.set_a1("A");
+  vd1.set_a2("T");
+  vd1.set_varid("rs1");
+  igp::vardata vd2 = vd1;
+  EXPECT_EQ(vd1.get_chr(), vd2.get_chr());
+  EXPECT_EQ(vd1.get_pos1(), vd2.get_pos1());
+  EXPECT_EQ(vd1.get_pos2(), vd2.get_pos2());
+  EXPECT_EQ(vd1.get_a1(), vd2.get_a1());
+  EXPECT_EQ(vd1.get_a2(), vd2.get_a2());
+  EXPECT_EQ(vd1.get_varid(), vd2.get_varid());
+}
+
 TEST(vardataTest, testGetSet) {
   igp::vardata vd;
   vd.set_chr("chr1");

--- a/unit_tests/vardata_test.cc
+++ b/unit_tests/vardata_test.cc
@@ -1,0 +1,46 @@
+/*!
+ \file vardata_test.cc
+ \brief test of variant metadata storage class.
+ \copyright Released under the MIT License.
+ Copyright 2023 Lightning Auriga
+ */
+
+#include "gtest/gtest.h"
+#include "unit_tests/input_variant_file_test.h"
+
+namespace igp = interpolate_genetic_position;
+
+TEST(vardataTest, defaultConstructor) { igp::vardata vd; }
+
+TEST(vardataTest, copyConstructor) {
+  igp::vardata vd1;
+  vd1.set_chr("chr1");
+  vd1.set_pos1(100);
+  vd1.set_pos2(200);
+  vd1.set_a1("A");
+  vd1.set_a2("T");
+  vd1.set_varid("rs1");
+  igp::vardata vd2(vd1);
+  EXPECT_EQ(vd1.get_chr(), vd2.get_chr());
+  EXPECT_EQ(vd1.get_pos1(), vd2.get_pos1());
+  EXPECT_EQ(vd1.get_pos2(), vd2.get_pos2());
+  EXPECT_EQ(vd1.get_a1(), vd2.get_a1());
+  EXPECT_EQ(vd1.get_a2(), vd2.get_a2());
+  EXPECT_EQ(vd1.get_varid(), vd2.get_varid());
+}
+
+TEST(vardataTest, testGetSet) {
+  igp::vardata vd;
+  vd.set_chr("chr1");
+  vd.set_pos1(100);
+  vd.set_pos2(200);
+  vd.set_a1("A");
+  vd.set_a2("T");
+  vd.set_varid("rs1");
+  EXPECT_EQ(vd.get_chr(), "chr1");
+  EXPECT_EQ(vd.get_pos1(), mpz_class(100));
+  EXPECT_EQ(vd.get_pos2(), mpz_class(200));
+  EXPECT_EQ(vd.get_a1(), "A");
+  EXPECT_EQ(vd.get_a2(), "T");
+  EXPECT_EQ(vd.get_varid(), "rs1");
+}


### PR DESCRIPTION
- non-contiguous regions in bedfiles cause dummy intervals to be injected into the output bolt-format genetic map. this prevents incorrect implied interpolation in uncovered regions. this closes #15 
- the experimental incrementing of genetic position at bedfile query boundaries now respects query column 4, such that a query with the same column 4 entry as the previous query will _not_ have its genetic position incremented. this allows distinct queries to be assigned to a single conceptual unit. this closes #16 