### PR TITLE
Improve configurable handling of precision

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1]
+
+### Added
+
+- parameter `--precision` to control bits used in RAM for floating point math
+- parameter `--fixed-output-width` to control digits printed after decimal for output values
+
+### Fixed
+
+- program automatically detects certain types of accumulated rounding errors and crashes
+  with a somewhat informative error message
+
 ## [1.2.0]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ By default, the final compiled program can be run with
 |`--verbose`<br>`-v`|Whether to print extremely verbose debug logs. You probably don't want this.|
 |`--output-morgans`|Report output genetic position in morgans, instead of the default centimorgans.|
 |`--region-step-interval`|Add a fixed genetic distance at the boundaries of end positions of bedfile region queries, such that the output data have a step-like structure. This functionality is included for experimental purposes, and in most applications this setting should be kept at its default of 0.|
+|`--precision`|Specify the number of bits to use for internal floating point calculations. Higher values will lead to higher fidelity calculations, at the cost of RAM and potentially performance. The program is capable of detecting situations where it has experienced catastrophic floating point errors, and in such a situation, try increasing this value to fix the problem. Default is 64.|
+|`--fixed-output-width`|Specify the number of digits after the decimal to be reported in output floating point values. More digits will potentially lead to more consistent downstream interpolation calculations, at the cost of file size. Leaving this unspecified or setting this to 0 causes the output floating point width to be scaled to the number of significant digits per value.|
 |`--help`<br>`-h`|Print brief help message and exit.|
 |`--version`|Print version string for current build.|
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,28 @@ or written to stream, simply omit its relevant flag (`-i`, `-g`, `-o`). For inpu
 format flag should still be set. Only one input stream (either `-i` or `-g`) can be read from an input stream
 per run.
 
+## Floating Point Precision
+
+The recombination rates and physical positions involved in these maps creates situations where some interpolations
+create extremely small differences in estimated recombination rates. Fixed precision in computational
+calculations and output files can create cascading rounding errors when using
+genetic maps to annotate, for example, a series of variants on a chromosome where the genetic position
+of successive variants must never _decrease_, even by a very small amount.
+
+To allow the user to conditionally avoid this difficulty, the program offers the following:
+
+- the program will check its output genetic positions and error out if it finds a position that decreases
+  relative to the prior output result;
+- the program has the configuration flag `--precision` that controls the amount of memory in RAM that is
+  used for calculations; and
+- the program has the configuration flag `--fixed-output-width` that controls the number of digits
+  after the decimal place that are reported for any decimal value in its output.
+
+If the user encounters the error in the first point above, they can then increase in tandem the values
+of `--precision` and `--fixed-output-width` until the observed errors go away. Unfortunately, it is extremely
+challenging to predict how to adjust these values without simply trying different combinations. In a test
+case with real data, the permutation of values `--precision 256 --fixed-width 60` addressed all observed issues.
+
 ## Example Use Cases
 
 ### Take a plink-format genotype dataset, annotate with interpolated genetic positions

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.71])
-AC_INIT(interpolate-genetic-position, 1.2.0, lightning.auriga@gmail.com)
+AC_INIT(interpolate-genetic-position, 1.2.1, lightning.auriga@gmail.com)
 AC_CONFIG_AUX_DIR([.])
 AM_INIT_AUTOMAKE([-Wall -Werror subdir-objects])
 AM_SILENT_RULES([yes])
@@ -50,7 +50,7 @@ AC_CHECK_LIB([m],[cos])
 
 AC_CONFIG_FILES([
  Makefile
- interpolate-genetic-position-1.2.0.pc
+ interpolate-genetic-position-1.2.1.pc
 ])
 
 AC_OUTPUT

--- a/integration_tests/integration_test.cc
+++ b/integration_tests/integration_test.cc
@@ -217,7 +217,7 @@ TEST_F(integrationTest, vcfInputMapOutput) {
       "chr3\trs3\t0\t1000000\n";
   igp::interpolator ip;
   ip.interpolate("unit_tests/test.vcf.gz", "vcf", _in_gmap_tmpfile, "bolt",
-                 _out_tmpfile, "map", false, 0.0, false);
+                 _out_tmpfile, "map", false, 0.0, 0, false);
   EXPECT_TRUE(boost::filesystem::exists(_out_tmpfile));
   std::string observed_output = load_plaintext_file(_out_tmpfile);
   EXPECT_EQ(expected_output, observed_output);
@@ -232,7 +232,7 @@ TEST_F(integrationTest, vcfInputBimOutput) {
       "chr3\trs3\t0\t1000000\tA\tC\n";
   igp::interpolator ip;
   ip.interpolate("unit_tests/test.vcf.gz", "vcf", _in_gmap_tmpfile, "bolt",
-                 _out_tmpfile, "bim", false, 0.0, false);
+                 _out_tmpfile, "bim", false, 0.0, 0, false);
   EXPECT_TRUE(boost::filesystem::exists(_out_tmpfile));
   std::string observed_output = load_plaintext_file(_out_tmpfile);
   EXPECT_EQ(expected_output, observed_output);
@@ -255,7 +255,7 @@ TEST_F(integrationTest, bedfileInputBoltOutputNoIncrement) {
       "chr3\t1000000\t0\t0\n";
   igp::interpolator ip;
   ip.interpolate(_in_query_tmpfile, "bed", _in_gmap_tmpfile, "bolt",
-                 _out_tmpfile, "bolt", false, 0.0, false);
+                 _out_tmpfile, "bolt", false, 0.0, 0, false);
   EXPECT_TRUE(boost::filesystem::exists(_out_tmpfile));
   std::string observed_output = load_plaintext_file(_out_tmpfile);
   EXPECT_EQ(expected_output, observed_output);
@@ -279,7 +279,7 @@ TEST_F(integrationTest, bedfileInputBoltOutputBoundaryIncrement) {
       "chr3\t1000000\t0\t0\n";
   igp::interpolator ip;
   ip.interpolate(_in_query_tmpfile, "bed", _in_gmap_tmpfile, "bolt",
-                 _out_tmpfile, "bolt", false, boundary_increment, false);
+                 _out_tmpfile, "bolt", false, boundary_increment, 0, false);
   EXPECT_TRUE(boost::filesystem::exists(_out_tmpfile));
   std::string observed_output = load_plaintext_file(_out_tmpfile);
   EXPECT_EQ(expected_output, observed_output);
@@ -296,7 +296,7 @@ TEST_F(integrationTest, bimfileInputBimfileOutput) {
       "3\trs3\t0\t1000000\tA\tC\n";
   igp::interpolator ip;
   ip.interpolate(_in_query_tmpfile, "bim", _in_gmap_tmpfile, "bolt",
-                 _out_tmpfile, "bim", false, 0.0, false);
+                 _out_tmpfile, "bim", false, 0.0, 0, false);
   EXPECT_TRUE(boost::filesystem::exists(_out_tmpfile));
   std::string observed_output = load_plaintext_file(_out_tmpfile);
   EXPECT_EQ(expected_output, observed_output);
@@ -313,7 +313,7 @@ TEST_F(integrationTest, mapfileInputMapfileOutput) {
       "3\trs3\t0\t1000000\n";
   igp::interpolator ip;
   ip.interpolate(_in_query_tmpfile, "map", _in_gmap_tmpfile, "bolt",
-                 _out_tmpfile, "map", false, 0.0, false);
+                 _out_tmpfile, "map", false, 0.0, 0, false);
   EXPECT_TRUE(boost::filesystem::exists(_out_tmpfile));
   std::string observed_output = load_plaintext_file(_out_tmpfile);
   EXPECT_EQ(expected_output, observed_output);
@@ -333,7 +333,7 @@ TEST_F(integrationTest, gzippedMapfileInputMapfileOutput) {
         "3\trs3\t0\t1000000\n";
     igp::interpolator ip;
     ip.interpolate(in_query_tmpfile, "map", _in_gmap_tmpfile, "bolt",
-                   _out_tmpfile, "map", false, 0.0, false);
+                   _out_tmpfile, "map", false, 0.0, 0, false);
     EXPECT_TRUE(boost::filesystem::exists(_out_tmpfile));
     std::string observed_output = load_plaintext_file(_out_tmpfile);
     EXPECT_EQ(expected_output, observed_output);
@@ -360,7 +360,7 @@ TEST_F(integrationTest, gzippedBoltGeneticMap) {
         "3\trs3\t0\t1000000\n";
     igp::interpolator ip;
     ip.interpolate(_in_query_tmpfile, "map", in_gmap_tmpfile, "bolt",
-                   _out_tmpfile, "map", false, 0.0, false);
+                   _out_tmpfile, "map", false, 0.0, 0, false);
     EXPECT_TRUE(boost::filesystem::exists(_out_tmpfile));
     std::string observed_output = load_plaintext_file(_out_tmpfile);
     EXPECT_EQ(expected_output, observed_output);
@@ -383,7 +383,7 @@ TEST_F(integrationTest, bedgraphGeneticMap) {
       "3\trs3\t0\t1000000\n";
   igp::interpolator ip;
   ip.interpolate(_in_query_tmpfile, "map", _in_gmap_tmpfile, "bedgraph",
-                 _out_tmpfile, "map", false, 0.0, false);
+                 _out_tmpfile, "map", false, 0.0, 0, false);
   EXPECT_TRUE(boost::filesystem::exists(_out_tmpfile));
   std::string observed_output = load_plaintext_file(_out_tmpfile);
   EXPECT_EQ(expected_output, observed_output);
@@ -399,7 +399,7 @@ TEST_F(integrationTest, bigwigGeneticMap) {
       "3\trs3\t0\t1000000\n";
   igp::interpolator ip;
   ip.interpolate(_in_query_tmpfile, "map", _in_gmap_tmpfile, "bigwig",
-                 _out_tmpfile, "map", false, 0.0, false);
+                 _out_tmpfile, "map", false, 0.0, 0, false);
   EXPECT_TRUE(boost::filesystem::exists(_out_tmpfile));
   std::string observed_output = load_plaintext_file(_out_tmpfile);
   EXPECT_EQ(expected_output, observed_output);
@@ -427,7 +427,7 @@ TEST_F(integrationTest, bedfileInputBoltOutputSparseQueries) {
       "chr22\t17084146\t0\t0.00107285\n";
   igp::interpolator ip;
   ip.interpolate(_in_query_tmpfile, "bed", _in_gmap_tmpfile, "bedgraph",
-                 _out_tmpfile, "bolt", false, 0.0, false);
+                 _out_tmpfile, "bolt", false, 0.0, 0, false);
   EXPECT_TRUE(boost::filesystem::exists(_out_tmpfile));
   std::string observed_output = load_plaintext_file(_out_tmpfile);
   EXPECT_EQ(expected_output, observed_output);
@@ -458,7 +458,7 @@ TEST_F(integrationTest, bedfileInputRespectLabelColumn) {
       "chr22\t17084146\t0\t0.201073\n";
   igp::interpolator ip;
   ip.interpolate(_in_query_tmpfile, "bed", _in_gmap_tmpfile, "bedgraph",
-                 _out_tmpfile, "bolt", false, 0.1, false);
+                 _out_tmpfile, "bolt", false, 0.1, 0, false);
   EXPECT_TRUE(boost::filesystem::exists(_out_tmpfile));
   std::string observed_output = load_plaintext_file(_out_tmpfile);
   EXPECT_EQ(expected_output, observed_output);

--- a/interpolate-genetic-position-1.2.1.pc.in
+++ b/interpolate-genetic-position-1.2.1.pc.in
@@ -8,4 +8,4 @@ Description: Use reference genetic map to interpolate genetic position for a que
 Requires: gcc >= 8.2.0
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir}
-Cflags: -I${includedir}/interpolate-genetic-position-1.2.0 -I${libdir}/interpolate-genetic-position-1.2.0/include
+Cflags: -I${includedir}/interpolate-genetic-position-1.2.1 -I${libdir}/interpolate-genetic-position-1.2.1/include

--- a/interpolate-genetic-position.doxyfile
+++ b/interpolate-genetic-position.doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "interpolate-genetic-position"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.2.0
+PROJECT_NUMBER         = 1.2.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/interpolate-genetic-position/cargs.cc
+++ b/interpolate-genetic-position/cargs.cc
@@ -50,7 +50,16 @@ void igp::cargs::initialize_options() {
       "region-step-interval",
       boost::program_options::value<double>()->default_value(0.0),
       "genetic distance increment to add at boundaries of bed interval; "
-      "experimental, generally should be kept at default");
+      "experimental, generally should be kept at default")(
+      "precision", boost::program_options::value<unsigned>()->default_value(64),
+      "set bits used for floating point precision in calculations; "
+      "bigger leads to higher precision at the cost of RAM and possibly "
+      "performance")(
+      "fixed-output-width", boost::program_options::value<unsigned>(),
+      "set width of output floating point values. larger width will "
+      "potentially lead to more reasonable downstream interpolation, "
+      "at the cost of file size. leaving this unset or set to 0 will cause "
+      "the output width to be dynamically scaled to significant digits");
 }
 
 bool igp::cargs::help() const { return compute_flag("help"); }
@@ -106,6 +115,24 @@ bool igp::cargs::output_morgans() const {
 
 double igp::cargs::get_region_step_interval() const {
   return compute_parameter<double>("region-step-interval");
+}
+
+unsigned igp::cargs::get_mpf_precision() const {
+  unsigned res = compute_parameter<unsigned>("precision");
+  if (res < 64) {
+    throw std::runtime_error(
+        "cargs::get_mpf_precision: minimum permitted "
+        "precision value at this time is 64");
+  }
+  return res;
+}
+
+unsigned igp::cargs::get_fixed_output_width() const {
+  unsigned res = 0;
+  if (_vm.count("fixed-output-width")) {
+    res = compute_parameter<unsigned>("fixed-output-width");
+  }
+  return res;
 }
 
 bool igp::cargs::compute_flag(const std::string &tag) const {

--- a/interpolate-genetic-position/cargs.h
+++ b/interpolate-genetic-position/cargs.h
@@ -142,6 +142,28 @@ class cargs {
    */
   double get_region_step_interval() const;
   /*!
+   * \brief get user-specified precision for internal floating point
+   * calculations. \return user-specified precision for internal floating point
+   * calculations.
+   *
+   * This number controls stored precision in arbitrary precision calculations;
+   * bigger numbers mean higher precision, at the cost of RAM and potentially
+   * performance. The default value on the test system is 64 (8 bytes).
+   */
+  unsigned get_mpf_precision() const;
+  /*!
+   * \brief get fixed width of output floating point values.
+   * \return user-specified fixed width of floating point values
+   *
+   * Depending on the calculations required downstream, a high amount of output
+   * precision may be required in order for later interpolation to provide
+   * consistent results without accumulated precision errors.
+   *
+   * Leaving this unset or setting it to 0 will cause the default gmp
+   * behavior of dynamic output width to be used.
+   */
+  unsigned get_fixed_output_width() const;
+  /*!
     \brief find status of arbitrary flag
     @param tag name of flag
     \return whether the flag is set

--- a/interpolate-genetic-position/interpolator.cc
+++ b/interpolate-genetic-position/interpolator.cc
@@ -16,12 +16,14 @@ void igp::interpolator::interpolate(
     const std::string &input_filename, const std::string &preset,
     const std::string &genetic_map_filename, const std::string &map_format,
     const std::string &output_filename, const std::string &output_format,
-    bool output_morgans, const double &step_interval, bool verbose) const {
+    bool output_morgans, const double &step_interval,
+    unsigned fixed_output_width, bool verbose) const {
   input_variant_file input_variant_interface;
   input_genetic_map_file genetic_map_interface;
   output_variant_file output_variant_interface;
   input_variant_interface.set_fallback_stream(&std::cin);
   output_variant_interface.output_morgans(output_morgans);
+  output_variant_interface.set_fixed_width(fixed_output_width);
   genetic_map_interface.set_fallback_stream(&std::cin);
   genetic_map gm(&genetic_map_interface);
   format_type map_ft = string_to_format_type(map_format);

--- a/interpolate-genetic-position/interpolator.h
+++ b/interpolate-genetic-position/interpolator.h
@@ -57,6 +57,9 @@ class interpolator {
    * within regions behaves linearly regardless. this functionality,
    * when set to 0, is effectively disabled. this parameter is ignored
    * for all input types other than bedfiles.
+   * \param fixed_output_width number of digits to print after
+   * decimal for output floating point values, or 0 for the number
+   * of digits to be scaled dynamically based on the number of sigfigs
    * \param verbose whether to emit (extremely) verbose logging to std::cout
    * can be empty string, in which case output is std::cout
    */
@@ -65,7 +68,8 @@ class interpolator {
                    const std::string &map_format,
                    const std::string &output_filename,
                    const std::string &output_format, bool output_morgans,
-                   const double &step_interval, bool verbose) const;
+                   const double &step_interval, unsigned fixed_output_width,
+                   bool verbose) const;
 };
 }  // namespace interpolate_genetic_position
 

--- a/interpolate-genetic-position/main.cc
+++ b/interpolate-genetic-position/main.cc
@@ -42,6 +42,8 @@ int main(int argc, const char** const argv) {
     return 0;
   }
 
+  mpf_set_default_prec(ap.get_mpf_precision());
+
   std::string input = ap.get_input_filename();
   std::string preset = ap.get_input_preset();
   std::string genetic_map = ap.get_recombination_map();
@@ -51,6 +53,7 @@ int main(int argc, const char** const argv) {
   bool verbose = ap.verbose();
   bool output_morgans = ap.output_morgans();
   double step_interval = ap.get_region_step_interval();
+  unsigned fixed_output_width = ap.get_fixed_output_width();
   if (input.empty() && genetic_map.empty()) {
     throw std::runtime_error("only one of -i and -g can be read from stdin");
   }
@@ -64,7 +67,7 @@ int main(int argc, const char** const argv) {
 
   igp::interpolator ip;
   ip.interpolate(input, preset, genetic_map, map_format, output, output_format,
-                 output_morgans, step_interval, verbose);
+                 output_morgans, step_interval, fixed_output_width, verbose);
 
   if (verbose) {
     std::cout << "all done woo!" << std::endl;

--- a/interpolate-genetic-position/output_variant_file.cc
+++ b/interpolate-genetic-position/output_variant_file.cc
@@ -108,6 +108,15 @@ void igp::output_variant_file::write(
     }
     set_last_chr(chr);
     set_index_on_chromosome(0);
+  } else {
+    // as a last resort, check uncontrolled precision errors in output
+    if (cmp(get_last_gpos(), output_gpos) > 0) {
+      throw std::runtime_error(
+          "write: an output genetic position is smaller than the position "
+          "of a previous output for the same chromosome. This is probably "
+          "caused by uncontrolled precision errors, either in one of the "
+          "inputs or in the logic of this program.");
+    }
   }
   set_last_pos1(pos1);
   set_last_pos2(pos2);

--- a/interpolate-genetic-position/output_variant_file.cc
+++ b/interpolate-genetic-position/output_variant_file.cc
@@ -23,7 +23,8 @@ igp::output_variant_file::output_variant_file()
       _last_gpos(0.0),
       _last_rate(0.0),
       _step_interval(0.0),
-      _index_on_chromosome(0) {}
+      _index_on_chromosome(0),
+      _fixed_width(0) {}
 
 igp::output_variant_file::~output_variant_file() throw() { close(); }
 
@@ -84,6 +85,11 @@ void igp::output_variant_file::write(
     const std::string &a1, const std::string &a2) {
   // the idea is: format an output line, then emit it to appropriate target
   std::ostringstream out;
+  // set fixed width if a non-zero width has been specified
+  if (get_fixed_width()) {
+    out.precision(get_fixed_width());
+    out << std::fixed;
+  }
   format_type ft = get_format();
 
   mpf_class step_interval = get_step_interval();
@@ -115,7 +121,10 @@ void igp::output_variant_file::write(
           "write: an output genetic position is smaller than the position "
           "of a previous output for the same chromosome. This is probably "
           "caused by uncontrolled precision errors, either in one of the "
-          "inputs or in the logic of this program.");
+          "inputs or in the logic of this program. The most likely way to "
+          "solve this error is to try increasing --precision and "
+          "--fixed-output-width in combination until sufficient precision "
+          "is preserved for the results to remain internally consistent.");
     }
   }
   set_last_pos1(pos1);
@@ -201,4 +210,12 @@ unsigned igp::output_variant_file::get_index_on_chromosome() const {
 
 void igp::output_variant_file::set_index_on_chromosome(unsigned index) {
   _index_on_chromosome = index;
+}
+
+void igp::output_variant_file::set_fixed_width(unsigned width) {
+  _fixed_width = width;
+}
+
+unsigned igp::output_variant_file::get_fixed_width() const {
+  return _fixed_width;
 }

--- a/interpolate-genetic-position/output_variant_file.h
+++ b/interpolate-genetic-position/output_variant_file.h
@@ -163,6 +163,16 @@ class base_output_variant_file {
    * \param index index of this result
    */
   virtual void set_index_on_chromosome(unsigned index) = 0;
+  /*!
+   * \brief set fixed width for output floats
+   * \param width fixed width for output floats
+   */
+  virtual void set_fixed_width(unsigned width) = 0;
+  /*!
+   * \brief get fixed width for output floats
+   * \return fixed width for output floats
+   */
+  virtual unsigned get_fixed_width() const = 0;
 };
 
 /*!
@@ -307,6 +317,16 @@ class output_variant_file : public base_output_variant_file {
    * \param index index of this result
    */
   void set_index_on_chromosome(unsigned index);
+  /*!
+   * \brief set fixed width for output floats
+   * \param width fixed width for output floats
+   */
+  void set_fixed_width(unsigned width);
+  /*!
+   * \brief get fixed width for output floats
+   * \return fixed width for output floats
+   */
+  unsigned get_fixed_width() const;
 
  private:
   std::ofstream _output;     //!< output uncompressed file stream
@@ -320,6 +340,7 @@ class output_variant_file : public base_output_variant_file {
   mpf_class _step_interval;  //!< gpos increment to edge of bed queries
   unsigned _index_on_chromosome;  //!< how many queries have been returned on
                                   //!< this chromosome
+  unsigned _fixed_width;          //!< fixed width of output decimal values
 };
 }  // namespace interpolate_genetic_position
 

--- a/unit_tests/cargs_test.cc
+++ b/unit_tests/cargs_test.cc
@@ -29,7 +29,7 @@ cargsTest::cargsTest()
   populate(test3, &_argvec3, &_argv3);
   std::string test4 = "progname -i fn1 -p bedgraph -g fn2 -m map -o fn3 -f vcf";
   populate(test4, &_argvec4, &_argv4);
-  std::string test5 = "progname --version";
+  std::string test5 = "progname --version --precision 68";
   populate(test5, &_argvec5, &_argv5);
 }
 
@@ -145,4 +145,9 @@ TEST_F(cargsTest, detectImproperFormats) {
   EXPECT_THROW(ap.get_input_preset(), std::runtime_error);
   EXPECT_THROW(ap.get_map_format(), std::runtime_error);
   EXPECT_THROW(ap.get_output_format(), std::runtime_error);
+}
+
+TEST_F(cargsTest, detectPrecision) {
+  igp::cargs ap(_argvec5.size(), _argv5);
+  EXPECT_EQ(ap.get_mpf_precision(), 68u);
 }

--- a/unit_tests/output_variant_file_test.h
+++ b/unit_tests/output_variant_file_test.h
@@ -55,6 +55,8 @@ class mock_output_variant_file : public base_output_variant_file {
   MOCK_METHOD(void, set_step_interval, (const mpf_class &), (override));
   MOCK_METHOD(unsigned, get_index_on_chromosome, (), (const, override));
   MOCK_METHOD(void, set_index_on_chromosome, (unsigned), (override));
+  MOCK_METHOD(unsigned, get_fixed_width, (), (const, override));
+  MOCK_METHOD(void, set_fixed_width, (unsigned), (override));
 };
 }  // namespace interpolate_genetic_position
 #endif  // UNIT_TESTS_OUTPUT_VARIANT_FILE_TEST_H_


### PR DESCRIPTION
- add `--precision` parameter, to control bits used in internal floating point calculations
- add `--fixed-output-width` parameter, to control number of digits after decimal in output reporting

I noticed in using this tool in repeated steps that sufficient precision error was being created that certain boundary interpolation cases were failing at high precision values, leading to out of order genetic positions at the boundaries of bins in the input genetic map. The combination of the above introduced flags allows enough precision to be maintained to "guarantee" that the final output of a series of pipes has coherent rounding behavior. `--fixed-output-width` can be left unspecified to have the usual dynamic output length, and this is probably appropriate at the last step of a series of pipes when the distances become, more or less, fixed.